### PR TITLE
Fix Type Annotation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import { sample } from './grpc-namespaces';
 const server = serverBuilder<sample.ServerBuilder>('sample.proto', 'sample')
 // Add implementation
 server.addGreeter({
-  sayHello(request: sample.HelloReply) {
+  sayHello(request: sample.HelloRequest) {
     return Observable.of({
       message: 'Hello ' + request.name
     });


### PR DESCRIPTION
Minor fix to the example server. Updated the type annotation from HelloReply > HelloRequest. 

Awesome library by the way. I was looking into building something similar (gRPC + TypeScript + RxJS), so I was glad to stumble on this first. 