### PR TITLE
Add missing import of $protobuf

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,7 +170,7 @@ function transformTypeScriptSource(source: string) {
   // Remove imports
   source = source.replace(/^import.*?$\n?/mg, '');
   // Add our imports
-  source = `import { Observable } from 'rxjs';\n${source}`;
+  source = `import { Observable } from 'rxjs';\nimport * as $protobuf from 'protobufjs';\n${source}`;
   // Fix generic type syntax
   source = source.replace(/Observable\.</g, 'Observable<');
   // Export interfaces, enums and namespaces

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,7 +170,12 @@ function transformTypeScriptSource(source: string) {
   // Remove imports
   source = source.replace(/^import.*?$\n?/mg, '');
   // Add our imports
-  source = `import { Observable } from 'rxjs';\nimport * as $protobuf from 'protobufjs';\n${source}`;
+  source = `import { Observable } from 'rxjs';\n${source}`;
+
+  if(source.includes("$protobuf")) {
+    source = `import * as $protobuf from 'protobufjs';\n${source}`
+  }
+
   // Fix generic type syntax
   source = source.replace(/Observable\.</g, 'Observable<');
   // Export interfaces, enums and namespaces

--- a/src/tests/messages.test.ts
+++ b/src/tests/messages.test.ts
@@ -14,6 +14,7 @@ describe('messages test', () => {
         message Message {
           string name = 1;
           uint32 number = 2;
+          int64 number2 = 3;
         }
       `
     ]);


### PR DESCRIPTION
Fix for issue #8.

When a new typescript file is generated an import for `$protobuf` is added. 

Modified the test message to contain an int64 field. Without the `$protobuf` import this will make the test fail.