### PR TITLE
feature(GrpcTypings): add forceShutdown to grpc interface

### DIFF
--- a/src/tests/examples.test.ts
+++ b/src/tests/examples.test.ts
@@ -6,6 +6,16 @@ import * as cli from '../cli';
 import { compileInMemory, Sources } from './utils';
 
 describe('compile/examples', () => {
+  let originalTimeout: number;
+
+  beforeEach(() => {
+      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+  });
+
+  afterEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
 
   const EXAMPLES_FOLDER = path.join(__dirname, '..', '..', 'examples');
 

--- a/src/tests/full-api.test.ts
+++ b/src/tests/full-api.test.ts
@@ -4,6 +4,16 @@ import { compileInMemory } from './utils';
 describe('full api test', () => {
 
   let namespaces: string;
+  let originalTimeout: number;
+
+  beforeEach(() => {
+      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+  });
+
+  afterEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
 
   beforeAll(async () => {
     namespaces = await cli.buildTypeScriptFromSources([

--- a/src/tests/multiple-namespaces.test.ts
+++ b/src/tests/multiple-namespaces.test.ts
@@ -4,6 +4,17 @@ import { compileInMemory } from './utils';
 describe('multiple namespaces test', () => {
 
   let namespaces: string;
+  let originalTimeout: number;
+
+  beforeEach(() => {
+      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+  });
+
+  afterEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
+
 
   beforeAll(async () => {
     namespaces = await cli.buildTypeScriptFromSources([

--- a/src/tests/multiple-services.test.ts
+++ b/src/tests/multiple-services.test.ts
@@ -4,6 +4,16 @@ import { compileInMemory } from './utils';
 describe('multiple services test', () => {
 
   let namespaces: string;
+  let originalTimeout: number;
+
+  beforeEach(() => {
+      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+  });
+
+  afterEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
 
   beforeAll(async () => {
     namespaces = await cli.buildTypeScriptFromSources([

--- a/src/tests/nested-namespaces.test.ts
+++ b/src/tests/nested-namespaces.test.ts
@@ -4,6 +4,16 @@ import { compileInMemory } from './utils';
 describe('nested namespaces test', () => {
 
   let namespaces: string;
+  let originalTimeout: number;
+
+  beforeEach(() => {
+      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+  });
+
+  afterEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
 
   beforeAll(async () => {
     namespaces = await cli.buildTypeScriptFromSources([

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -4,12 +4,13 @@ declare module 'grpc' {
     function load(protoPath: string): any;
 
     class Server {
-      addProtoService(service: any, impl: any): void;
+      addService(service: any, impl: any): void;
       bind(hostPort: string, cred: any): void;
       start(): void;
+      forceShutdown(): void;
     }
 
-    class credentials {
+    class Credentials {
       static createInsecure(): any;
     }
 


### PR DESCRIPTION
First of all thanks for the nice work of this package!

The purpose of this PR is a small enhancement to the GRPC Interface.

I enhanced the typings of the GRPC interface with the forceShutdown function. This fn is provided by the native GRPC Server implementation and quite important in my use case (https://grpc.io/grpc/node/grpc.Server.html).

In addition to that I removed the DeprecationWarning - Server#addProtoService by renaming the interface and all usages to Server#addService.

@kondi Pls. let me know if you have any questions.
I'm not sure why the tests are timing out on jenkins. They are passing locally.