### PR TITLE
Fix/generated file lints

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -179,7 +179,7 @@ function transformTypeScriptSource(source: string) {
   // Fix generic type syntax
   source = source.replace(/Observable\.</g, 'Observable<');
   // Export interfaces, enums and namespaces
-  source = source.replace(/^(\s+)(interface|enum|namespace)(\s+)/mg, '$1 export $2$3');
+  source = source.replace(/^(\s+)(interface|enum|namespace)(\s+)/mg, '$1export $2$3');
   return source;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,7 +170,7 @@ function transformTypeScriptSource(source: string) {
   // Remove imports
   source = source.replace(/^import.*?$\n?/mg, '');
   // Add our imports
-  source = `import { Observable } from 'rxjs';\n${source}`;
+  source = `import { Observable } from 'rxjs/Rx';\n${source}`;
 
   if(source.includes("$protobuf")) {
     source = `import * as $protobuf from 'protobufjs';\n${source}`


### PR DESCRIPTION
Thanks for setting up this useful tool! I just came across 2 small inconvenience using the generated Typescript files, that I've addressed with this PR:

The generated namespace Typescript files contain one space too many (e.g. 9 instead of 8) before `export` and the `rxjs` import should be `rxjs/Rx` to follow [RxJS' recomendation](https://github.com/ReactiveX/rxjs#es6-via-npm).

Happy holidays!