### PR TITLE
Propagate metadata to the server methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ function createMethod(rxImpl: DynamicMethods, name: string, serviceMethods: Dyna
 
 function createUnaryMethod(rxImpl: DynamicMethods, name: string) {
   return function(call: any, callback: any) {
-    const response: Observable<any> = rxImpl[name](call.request);
+    const response: Observable<any> = rxImpl[name](call.request, call.metadata);
     response.subscribe(
       data => callback(null, data),
       error => callback(error)
@@ -62,7 +62,7 @@ function createUnaryMethod(rxImpl: DynamicMethods, name: string) {
 
 function createStreamingMethod(rxImpl: DynamicMethods, name: string) {
   return async function(call: any, callback: any) {
-    const response: Observable<any> = rxImpl[name](call.request);
+    const response: Observable<any> = rxImpl[name](call.request, call.metadata);
     await response.forEach(data => call.write(data));
     call.end();
   };


### PR DESCRIPTION
Small fix to propagate the gRpc metadata during server side calls.
On top of the request parameter, this PR adds the metadata as a second argument.

Please note that implementation is not type-safe , it may need further discussion. Currently the client implementation also handles the metadata parameter the same way.