### PR TITLE
Pass proto root and proto file to grpc.load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,56 @@ yarn-error.log*
 # System Files
 .DS_Store
 Thumbs.db
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+

--- a/package.json
+++ b/package.json
@@ -27,29 +27,29 @@
     "setupTestFrameworkScriptFile": "./setup-jest"
   },
   "dependencies": {
-    "bluebird": "^3.4.7",
-    "grpc": "^1.1.2",
-    "jscodeshift": "^0.3.30",
-    "minimist": "^1.2.0",
-    "mz": "^2.6.0",
-    "protobufjs": "~6.6.5",
-    "tmp": "^0.0.31"
+    "bluebird": "3.4.7",
+    "grpc": "1.1.2",
+    "jscodeshift": "0.3.30",
+    "minimist": "1.2.0",
+    "mz": "2.6.0",
+    "protobufjs": "6.6.5",
+    "tmp": "0.0.31"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.0.37",
-    "@types/glob": "^5.0.30",
-    "@types/jasmine": "^2.5.43",
-    "@types/minimist": "^1.2.0",
-    "@types/mz": "^0.0.30",
-    "@types/node": "^7.0.5",
-    "@types/tmp": "^0.0.32",
-    "glob": "^7.1.1",
-    "grpc": "^1.1.2",
-    "jasmine": "^2.5.3",
-    "jest": "^21.2.1",
-    "rxjs": "^5.2.0",
-    "tslint": "^4.5.1",
-    "typescript": "^2.2.1"
+    "@types/bluebird": "3.0.37",
+    "@types/glob": "5.0.30",
+    "@types/jasmine": "2.5.43",
+    "@types/minimist": "1.2.0",
+    "@types/mz": "0.0.30",
+    "@types/node": "7.0.5",
+    "@types/tmp": "0.0.32",
+    "glob": "7.1.1",
+    "grpc": "1.1.2",
+    "jasmine": "2.5.3",
+    "jest": "21.2.1",
+    "rxjs": "5.2.0",
+    "tslint": "4.5.1",
+    "typescript": "2.2.1"
   },
   "peerDependencies": {
     "rxjs": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "js/index",
   "typings": "js/index",
-  "name": "rxjs-grpc",
+  "name": "@lexset/rxjs-grpc",
   "version": "0.1.7",
   "description": "Typesafe gRPC with RxJS in TypeScript",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "js/index",
   "typings": "js/index",
   "name": "@lexset/rxjs-grpc",
-  "version": "0.1.7",
+  "version": "0.1.89",
   "description": "Typesafe gRPC with RxJS in TypeScript",
   "license": "MIT",
   "keywords": [],
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "bluebird": "3.4.7",
-    "grpc": "1.1.2",
+    "grpc": "1.11.1",
     "jscodeshift": "0.3.30",
     "minimist": "1.2.0",
     "mz": "2.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export interface GenericServerBuilder<T> {
   forceShutdown(): void;
 }
 
-export function serverBuilder<T>(protoPath: string, packageName: string): T & GenericServerBuilder<T> {
+export function serverBuilder<T>(protoRoot: string, protoFile: string, packageName: string): T & GenericServerBuilder<T> {
   const server = new grpc.Server();
 
   const builder: DynamicMethods = <GenericServerBuilder<T>> {
@@ -23,7 +23,9 @@ export function serverBuilder<T>(protoPath: string, packageName: string): T & Ge
     }
   };
 
-  const pkg = lookupPackage(grpc.load(protoPath), packageName)
+  const pkg = lookupPackage(grpc.load({
+    root: protoRoot,
+    file: protoFile}), packageName);
   for (const name of getServiceNames(pkg)) {
     builder[`add${name}`] = function(rxImpl: DynamicMethods) {
       server.addProtoService(pkg[name].service, createService(pkg[name], rxImpl));
@@ -70,7 +72,7 @@ function createStreamingMethod(rxImpl: DynamicMethods, name: string) {
 
 export type ClientFactoryConstructor<T> = new(address: string, credentials?: any, options?: any) => T;
 
-export function clientFactory<T>(protoPath: string, packageName: string) {
+export function clientFactory<T>(protoRoot: string, protoFile: string, packageName: string) {
   class Constructor {
 
     readonly __args: any[];
@@ -85,7 +87,9 @@ export function clientFactory<T>(protoPath: string, packageName: string) {
   }
 
   const prototype: DynamicMethods = Constructor.prototype;
-  const pkg = lookupPackage(grpc.load(protoPath), packageName)
+  const pkg = lookupPackage(grpc.load({
+    root: protoRoot,
+    file: protoFile}), packageName);
   for (const name of getServiceNames(pkg)) {
     prototype[`get${name}`] = function(this: Constructor) {
       return createServiceClient(pkg[name], this.__args);

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,7 +1,8 @@
+
 declare module 'grpc' {
 
   namespace grpc {
-    function load(protoPath: string): any;
+    function load(options: LoadOptions): any;
 
     class Server {
       addProtoService(service: any, impl: any): void;
@@ -16,6 +17,11 @@ declare module 'grpc' {
 
     class ServerCredentials {
       static createInsecure(): any;
+    }
+
+    interface LoadOptions {
+      root: string;
+      file: string;
     }
   }
 


### PR DESCRIPTION
 I made a small change to pass proto root and proto file to `grpc.load()`, allowing for correct inclusion of additional protobuf files.

The interface becomes the following:

```
export declare function clientFactory<T>(protoFile: string, protoRoot: string, packageName: string): ClientFactoryConstructor<T>;
```

This allows us to do something like this in our service definitions, assuming that the imported proto files are available in the path provided when calling the above function:

```
import "google/api/annotations.proto";
...
  rpc Echo(StringMessage) returns (StringMessage) {
        option (google.api.http) = {
            post: "/user/echo"
            body: "*"
        };
  }
```

Unfortunately this isn't the cleanest pull request - I haven't had a chance to get the tests working because I can't seem to get them running on my machine. I also had to use Node v7.10.1 and NPM v4.2.0 and make some tweaks to package.json to get the thing building (there was a `yarn.lock` but not `package-json.lock` in `master`).

Getting this fork to a mergeable state shouldn't require much more effort, but I don't want to spend much time on it if there's not any interest in merging it.
