### PR TITLE
Correct import from 'rxjs' in generated file

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,7 +170,7 @@ function transformTypeScriptSource(source: string) {
   // Remove imports
   source = source.replace(/^import.*?$\n?/mg, '');
   // Add our imports
-  source = `import { Observable } from 'rxjs/Observable';\n${source}`;
+  source = `import { Observable } from 'rxjs';\n${source}`;
 
   if(source.includes("$protobuf")) {
     source = `import * as $protobuf from 'protobufjs';\n${source}`


### PR DESCRIPTION
Replace `import { Observable } from 'rxjs/Observable'` with `import { Observable } from 'rxjs'` in a generated file.